### PR TITLE
Unbreak build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ group = 'no.ok.origo.dataplatform'
 
 repositories {
   mavenCentral()
-  jcenter()
 }
 
 test {
@@ -23,8 +22,8 @@ dependencies {
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.+'
   implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.12.+"
   implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-  implementation 'com.github.kittinunf.fuel:fuel:2.2.0'
-  implementation 'com.github.kittinunf.fuel:fuel-jackson:2.2.0'
+  implementation 'com.github.kittinunf.fuel:fuel:2.3.1'
+  implementation 'com.github.kittinunf.fuel:fuel-jackson:2.3.1'
   implementation 'io.github.resilience4j:resilience4j-retry:1.7.0'
 
   implementation 'com.amazonaws:aws-lambda-java-core:1.1.0'


### PR DESCRIPTION
Unbreak the build by removing the obsolete JCenter repository and upgrading Fuel to a version that exists in Maven Central.